### PR TITLE
Added the ability to prevent default behavior when using key combinations

### DIFF
--- a/src/KeyPressAction.editorConfig.ts
+++ b/src/KeyPressAction.editorConfig.ts
@@ -116,6 +116,7 @@ export function getProperties(
     _values.watchList.forEach((keyEvent, index) => {
         if (!keyEvent.keyCombination) {
             hideNestedPropertiesIn(defaultProperties, _values, "watchList", index, ["secondaryKey"]);
+            hideNestedPropertiesIn(defaultProperties, _values, "watchList", index, ["preventDefault"]);
         }
     });
 

--- a/src/KeyPressAction.xml
+++ b/src/KeyPressAction.xml
@@ -65,6 +65,10 @@ When false, the event will only fire the first time the key is pressed down/up.<
                                     <enumerationValue key="META">Meta (Command / Windows)</enumerationValue>
                                 </enumerationValues>
                             </property>
+                            <property key="preventDefault" type="boolean" defaultValue="false">
+                                <caption>Prevent Default Behavior?</caption>
+                                <description>Should this event prevent default behavior, such as to override default browser CTRL+S behavior?</description>
+                            </property>
                             <property key="keyAction" type="action" required="true">
                                 <caption>Key action</caption>
                                 <description>Mendix action executed when this key or key combination is detected</description>

--- a/src/components/ContentWatcher.tsx
+++ b/src/components/ContentWatcher.tsx
@@ -52,6 +52,9 @@ const ContentWatcher = (props: KeyPressActionContainerProps): ReactElement => {
         }
 
         if (keyEvent && keyEvent.keyAction && keyEvent.keyAction.canExecute) {
+            if (keyEvent.preventDefault && keyEvent.keyCombination) {
+                event.preventDefault();
+            }
             DebugLog(debug, "keyEvent found: ", keyEvent);
             keyEvent.keyAction.execute();
         }

--- a/src/components/DocumentWatcher.tsx
+++ b/src/components/DocumentWatcher.tsx
@@ -47,6 +47,11 @@ const DocumentWatcher = (props: KeyPressActionContainerProps): ReactElement => {
             }
 
             if (keyEvent && keyEvent.keyAction && keyEvent.keyAction.canExecute) {
+
+                if (keyEvent.preventDefault && keyEvent.keyCombination) {
+                    event.preventDefault();
+                }
+
                 DebugLog(props.debug, "keyEvent found: ", keyEvent);
                 keyEvent.keyAction.execute();
             }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "@mendix/pluggable-widgets-tools/configs/tsconfig.base",
   "compilerOptions": {
+    "jsx": "react",
     "baseUrl": "./"
   },
   "include": ["./src", "./typings"]

--- a/typings/KeyPressActionProps.d.ts
+++ b/typings/KeyPressActionProps.d.ts
@@ -16,6 +16,7 @@ export interface WatchListType {
     keyName: string;
     keyCombination: boolean;
     secondaryKey: SecondaryKeyEnum;
+    preventDefault: boolean;
     keyAction?: ActionValue;
 }
 
@@ -23,6 +24,7 @@ export interface WatchListPreviewType {
     keyName: string;
     keyCombination: boolean;
     secondaryKey: SecondaryKeyEnum;
+    preventDefault: boolean;
     keyAction: {} | null;
 }
 


### PR DESCRIPTION
I see in the past this widget used event.preventDefaults(), but it was removed in a recent version. This was to fix a bug where the override prevented filling out form fields, but there is a very plausible use-case to enable the use of hotkeys which are normally controlled by the browser, like CTRL+S for saving, or CTRL+E (which focuses the search/omnibar).

This small addition to widget reintroduces the preventDefaults feature, and making it a toggleable boolean on individual key events only when multi-key combinations are enabled. 